### PR TITLE
fixing ARM compatibility issues

### DIFF
--- a/{{cookiecutter.repo_name}}/src/requirements.txt
+++ b/{{cookiecutter.repo_name}}/src/requirements.txt
@@ -8,7 +8,7 @@ jupyterlab~=3.0
 kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[pandas.CSVDataSet, pandas.ExcelDataSet, pandas.ParquetDataSet]~=1.0.0
 kedro-azureml[mlflow]~={{ cookiecutter.kedro_azureml_version }}
-kedro-docker~=0.3
+kedro-docker==0.3.5
 kedro-viz~=5.0
 nbstripout~=0.4
 pytest-cov~=3.0

--- a/{{cookiecutter.repo_name}}/src/requirements.txt
+++ b/{{cookiecutter.repo_name}}/src/requirements.txt
@@ -7,8 +7,8 @@ jupyterlab_server>=2.11.1, <2.16.0
 jupyterlab~=3.0
 kedro~={{ cookiecutter.kedro_version }}
 kedro-datasets[pandas.CSVDataSet, pandas.ExcelDataSet, pandas.ParquetDataSet]~=1.0.0
-kedro-azureml[mlflow]~={{ cookiecutter.kedro_azureml_version }}
-kedro-docker==0.3.5
+kedro-azureml[mlflow]=={{ cookiecutter.kedro_azureml_version }}
+kedro-docker~=0.3
 kedro-viz~=5.0
 nbstripout~=0.4
 pytest-cov~=3.0


### PR DESCRIPTION
Setting kedro-azureml version to 3.5 to avoid ARM-related incompatibilities (for mac users).